### PR TITLE
fix: release stored response body when a chunk read errors

### DIFF
--- a/rust/src/store/body_store.rs
+++ b/rust/src/store/body_store.rs
@@ -50,7 +50,7 @@ fn remove_body(handle: u64) -> Option<SharedBody> {
 
 pub fn read_body_chunk(handle: u64, _size: usize) -> Result<(Vec<u8>, bool)> {
     let body = get_body(handle)?;
-    let chunk = runtime().block_on(async {
+    let chunk = match runtime().block_on(async {
         let mut body = body.lock().await;
         loop {
             match body.response.frame().await {
@@ -64,7 +64,15 @@ pub fn read_body_chunk(handle: u64, _size: usize) -> Result<(Vec<u8>, bool)> {
             }
         }
         .context("Failed to read response body chunk")
-    })?;
+    }) {
+        Ok(chunk) => chunk,
+        Err(error) => {
+            // The body errored, so the connection is unusable — drop the stored body to release it and its
+            // socket instead of leaking the entry in BODY_STORE (mirrors the done-path cleanup below).
+            remove_body(handle);
+            return Err(error);
+        }
+    };
 
     let Some(chunk) = chunk else {
         remove_body(handle);


### PR DESCRIPTION
## Problem

`read_body_chunk` (`rust/src/store/body_store.rs`) removes the `BODY_STORE` entry only when the body reaches the end (the `None` branch) or is explicitly cancelled. When `body.response.frame()` returns `Some(Err(_))`, the `?` propagates the error **without** removing the entry, so the `StoredBody` — and the `wreq::Response` it owns (the open connection + pool slot) — stays in the global store indefinitely.

There is no finalizer for body handles, and on the JS side `Response`'s stream `pull` catches the read error and throws without calling `nativeCancelBody`, so the leaked entry is unreachable from consumers. A body that fails mid-stream (connection reset, read timeout, TLS drop) therefore leaks one socket per failure, which accumulates in a long-running process making many streamed requests.

## Fix

Remove the stored body on the error path too, mirroring the existing done-path `remove_body(handle)`, so the connection is released when a read errors.
